### PR TITLE
Fix/improve concurrency limiting

### DIFF
--- a/tests/test_deezer.py
+++ b/tests/test_deezer.py
@@ -43,11 +43,11 @@ def test_deezer_fallback_logic_with_mock_data(mock_deezer_client):
     """Unit test: fallback logic works with mocked track data"""
     # Mock track info where FLAC is unavailable but MP3_320 is available
     # quality_map: [(9, "MP3_128"), (3, "MP3_320"), (1, "FLAC")]
-    # So FILESIZE_9 = quality 0, FILESIZE_3 = quality 1, FILESIZE_1 = quality 2
+    # Code looks for FILESIZE_{format} keys
     mock_track_info = {
-        "FILESIZE_1": 0,      # FLAC unavailable (quality 2)
-        "FILESIZE_3": 5000000, # MP3_320 available (quality 1)
-        "FILESIZE_9": 2000000, # MP3_128 available (quality 0)
+        "FILESIZE_FLAC": 0,      # FLAC unavailable (quality 2)
+        "FILESIZE_MP3_320": 5000000, # MP3_320 available (quality 1)
+        "FILESIZE_MP3_128": 2000000, # MP3_128 available (quality 0)
         "TRACK_TOKEN": "test_token"
     }
     
@@ -67,9 +67,9 @@ def test_deezer_no_fallback_when_quality_available(mock_deezer_client):
     # Mock track info where FLAC is available
     # quality_map: [(9, "MP3_128"), (3, "MP3_320"), (1, "FLAC")]
     mock_track_info = {
-        "FILESIZE_1": 25000000, # FLAC available (quality 2)
-        "FILESIZE_3": 5000000,  # MP3_320 available (quality 1)
-        "FILESIZE_9": 2000000,  # MP3_128 available (quality 0)
+        "FILESIZE_FLAC": 25000000, # FLAC available (quality 2)
+        "FILESIZE_MP3_320": 5000000,  # MP3_320 available (quality 1)
+        "FILESIZE_MP3_128": 2000000,  # MP3_128 available (quality 0)
         "TRACK_TOKEN": "test_token"
     }
     
@@ -87,9 +87,9 @@ def test_deezer_fallback_to_lowest_available_quality(mock_deezer_client):
     # Mock track info where only MP3_128 is available
     # quality_map: [(9, "MP3_128"), (3, "MP3_320"), (1, "FLAC")]
     mock_track_info = {
-        "FILESIZE_1": 0,      # FLAC unavailable (quality 2)
-        "FILESIZE_3": 0,      # MP3_320 unavailable (quality 1)
-        "FILESIZE_9": 2000000, # MP3_128 available (quality 0)
+        "FILESIZE_FLAC": 0,      # FLAC unavailable (quality 2)
+        "FILESIZE_MP3_320": 0,      # MP3_320 unavailable (quality 1)
+        "FILESIZE_MP3_128": 2000000, # MP3_128 available (quality 0)
         "TRACK_TOKEN": "test_token"
     }
     

--- a/tests/test_tagger.py
+++ b/tests/test_tagger.py
@@ -62,6 +62,7 @@ def sample_metadata() -> TrackMetadata:
         3,
         1,
         "testcomposer",
+        "testauthor",  # Added required author field
     )
 
 


### PR DESCRIPTION
Problem

  The Deezer client was generating excessive "Connection pool is full, discarding
  connection: api.deezer.com. Connection pool size: 10" warnings due to:
  - No rate limiting implementation (unlike other clients)
  - No concurrency limiting for API requests
  - Connection pool size mismatch with concurrent request patterns

  Solution

  Added comprehensive rate and concurrency limiting:
  - Rate limiting: Respects Deezer's 10 req/sec API limit (600 req/min) using
  AsyncLimiter
  - Concurrency limiting: Uses asyncio.Semaphore to limit simultaneous connections
  - Dynamic connection pool: Configures HTTPAdapter with pool size matching user's
   max_connections config

  Configuration integration:
  - Uses config.session.downloads.requests_per_minute for rate limiting (defaults
  to 600 for Deezer's higher limits)
  - Uses config.session.downloads.max_connections for concurrency limiting
  - Eliminates artificial caps - users have full control via existing config
  values

  Enhanced error reporting:
  - Improved fallback warning messages with track/artist/album context
  - Better debugging information for quality fallback scenarios

  Testing

  - Fixed test mocks to use correct Deezer API data format (FILESIZE_MP3_128 vs
  FILESIZE_9)
  - Updated TrackMetadata test fixtures for new author field requirement
  - All existing tests pass with improved functionality

  Benefits

  - ✅ Eliminates connection pool overflow warnings
  - ✅ Respects Deezer API rate limits (10 req/sec)
  - ✅ Consistent behavior with other streaming clients
  - ✅ User-configurable connection limits
  - ✅ Better resource management and performance
  - ✅ Improved error messages for better UX

  Impact: Clean logs, proper API etiquette, and optimal performance while
  maintaining full backward compatibility.