### PR TITLE
Add Missing Metadata Fields to Qobuz

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -146,6 +146,30 @@ class AlbumMetadata:
         # Make sure it is non-empty list
         booklets = typed(resp.get("goodies", None) or None, list | None)
         item_id = str(resp.get("qobuz_id"))
+        
+        # Extract additional Qobuz metadata
+        barcode = resp.get("upc")
+        # Normalize release type casing: keep EP uppercase, others title case
+        raw_type = resp.get("release_type")
+        if raw_type:
+            if raw_type.upper() == "EP":
+                releasetype = "EP"
+            else:
+                releasetype = raw_type.title()  # Album, Single, etc.
+        else:
+            releasetype = None
+        originaldate = resp.get("release_date_original")
+        media_type = "Digital Media"  # MusicBrainz standard for digital/streaming sources
+        
+        # Source platform identification
+        source_platform = "qobuz"
+        source_album_id = item_id
+        # Get first artist ID for source_artist_id
+        source_artist_id = None
+        if artists:
+            source_artist_id = str(artists[0]["id"])
+        elif resp.get("artist", {}).get("id"):
+            source_artist_id = str(resp["artist"]["id"])
 
         if sampling_rate and bit_depth:
             container = "FLAC"
@@ -182,6 +206,13 @@ class AlbumMetadata:
             lyrics=None,
             purchase_date=None,
             tracktotal=tracktotal,
+            source_platform=source_platform,
+            source_album_id=source_album_id,
+            source_artist_id=source_artist_id,
+            barcode=barcode,
+            releasetype=releasetype,
+            originaldate=originaldate,
+            media_type=media_type,
         )
 
     @classmethod
@@ -425,7 +456,7 @@ class AlbumMetadata:
             sampling_rate=sampling_rate,
             bit_depth=bit_depth,
             booklets=None,
-            streamable=True,
+            streamable=streamable,
         )
         return AlbumMetadata(
             info,
@@ -549,7 +580,7 @@ class AlbumMetadata:
             sampling_rate=sampling_rate,
             bit_depth=bit_depth,
             booklets=None,
-            streamable=True,
+            streamable=streamable,
         )
         return AlbumMetadata(
             info,

--- a/streamrip/metadata/track.py
+++ b/streamrip/metadata/track.py
@@ -76,6 +76,25 @@ class TrackMetadata:
         track_id = str(resp["id"])
         bit_depth = typed(resp.get("maximum_bit_depth"), int | None)
         sampling_rate = typed(resp.get("maximum_sampling_rate"), int | float | None)
+        
+        # Extract ReplayGain data
+        replaygain_track_gain = None
+        audio_info = resp.get("audio_info", {})
+        if "replaygain_track_gain" in audio_info and audio_info["replaygain_track_gain"] is not None:
+            replaygain_track_gain = f"{audio_info['replaygain_track_gain']:+.2f} dB"
+        
+        # Extract performer information
+        performers_str = resp.get("performers")
+        
+        # Additional Qobuz metadata
+        media_type = "Digital Media"  # MusicBrainz standard for digital/streaming sources
+        source_platform = "qobuz"
+        source_track_id = track_id
+        qobuz_album_id = resp.get("album", {}).get("qobuz_id")
+        source_album_id = str(qobuz_album_id) if qobuz_album_id else None
+        performer_id = resp.get("performer", {}).get("id")
+        source_artist_id = str(performer_id) if performer_id else None
+        
         # Is the info included?
         explicit = False
 
@@ -96,9 +115,15 @@ class TrackMetadata:
             tracknumber=tracknumber,
             discnumber=discnumber,
             composer=composer,
-            author=None,
+            author=performers_str,  # Use performers string as author/credits
             artists=artists,
             isrc=isrc,
+            source_platform=source_platform,
+            source_track_id=source_track_id,
+            source_album_id=source_album_id,
+            source_artist_id=source_artist_id,
+            replaygain_track_gain=replaygain_track_gain,
+            media_type=media_type,
         )
 
     @classmethod  


### PR DESCRIPTION
Brings Qobuz metadata extraction in line with Deezer/Tidal by
adding fields available in raw API responses.

Changes

- releasetype - Album/EP/single detection from release_type
- barcode - UPC extraction from upc field
- ReplayGain - Audio normalization data from
audio_info.replaygain_track_gain
- Performers - Detailed credits from performers field
- Source IDs - Platform identification fields (source_platform,
 source_*_id)
- Standard fields - originaldate, media_type for consistency