### PR TITLE
Update tidal manifest

### DIFF
--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -219,10 +219,6 @@ class TidalClient(Client):
             else:  # JSONDecodeError
                 raise Exception(f"Failed to decode manifest for track {track_id}: {error_msg}")
 
-        enc_key = manifest_data.get("keyId")
-        if manifest_data.get("encryptionType") == "NONE":
-            enc_key = None
-
         # Handle both single URL and URL list formats
         urls = manifest_data.get("urls", [])
         if isinstance(urls, list) and len(urls) > 0:
@@ -234,7 +230,6 @@ class TidalClient(Client):
             self.session,
             url=url,
             codec=manifest_data["codecs"],
-            encryption_key=enc_key,
             restrictions=manifest_data.get("restrictions"),
         )
 


### PR DESCRIPTION
## Fix Tidal integration for updated API

### Summary
Updates Tidal client to work with current API changes. Tidal deprecated their old endpoints, changed authentication credentials, migrated to DASH manifests, and removed MQA encryption.

### Changes

**API Updates:**
- Update OAuth client credentials to working ones (old credentials were revoked)
- Change endpoint from `/playbackinfopostpaywall` to `/playbackinfo`
- Update quality parameter from `HI_RES` to `HI_RES_LOSSLESS`

**DASH Manifest Support:**
- Add MPEG-DASH XML manifest parser (`_parse_dash_manifest()`)
- Support both DASH (`application/dash+xml`) and legacy BTS (`application/vnd.tidal.bts`) formats
- Parse segment templates and generate segment URL lists

**Segmented Downloads:**
- Update `TidalDownloadable` to handle multi-segment downloads
- Download and concatenate DASH segments into final audio file

**OAuth Fix:**
- Add `allow_http_errors` parameter to `_request_with_retry()` 
- Fix device authorization polling to handle expected 400 responses during authentication flow

**Cleanup:**
- Remove deprecated MQA decryption code (Tidal no longer uses encryption)
- Remove unused `encryption_key` parameter and `_decrypt_mqa_file()` method
- Remove unused cryptography imports (`AES`, `Counter`, `base64`)